### PR TITLE
ci: Renovate に対して lock files を追いコミットするワークフローを追加

### DIFF
--- a/.github/workflows/auto-commit-lock-files.yml
+++ b/.github/workflows/auto-commit-lock-files.yml
@@ -1,0 +1,72 @@
+name: 'Add lockfiles commit against Renovate'
+
+on:
+  pull_request: ~
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  committer:
+    runs-on: ubuntu-24.04
+    outputs:
+      renovate: ${{ steps.check.outputs.renovate }}
+    steps:
+      - name: Check if last commit
+        id: check
+        run: |
+          if [[ "${{ github.event.pull_request.user.login }}" == "renovate[bot]" ]]; then
+            echo "renovate=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "renovate=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      bun: ${{ steps.filter.outputs.bun }}
+      pub: ${{ steps.filter.outputs.pub }}
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/marketplace/actions/paths-changes-filter
+      - name: Paths Changes Filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            bun:
+              - '**/package.json'
+            pub:
+              - '**/pubspec.yaml'
+
+  bun:
+    needs:
+      - committer
+      - changes
+    if: >
+      needs.committer.outputs.renovate == 'true' &&
+      needs.changes.outputs.bun == 'true'
+    name: bun.lockb
+    uses: ./.github/workflows/wc-bun-lockb.yml
+    with:
+      gh-app-id: ${{ vars.BOT_APP_ID }}
+    secrets:
+      gh-app-private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+  pub:
+    needs:
+      - committer
+      - changes
+    if: >
+      needs.committer.outputs.renovate == 'true' &&
+      needs.changes.outputs.pub == 'true'
+    name: pubspec.lock
+    uses: ./.github/workflows/wc-pubspec-locks.yml
+    with:
+      gh-app-id: ${{ vars.BOT_APP_ID }}
+    secrets:
+      gh-app-private-key: ${{ secrets.BOT_PRIVATE_KEY }}

--- a/.github/workflows/wc-bun-lockb.yml
+++ b/.github/workflows/wc-bun-lockb.yml
@@ -1,0 +1,91 @@
+name: 'Correct codes by auto generation'
+
+on:
+  workflow_call:
+    inputs:
+      gh-app-id:
+        required: true
+        type: string
+    secrets:
+      gh-app-private-key:
+        required: true
+
+jobs:
+  gen:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/marketplace/actions/mise-action
+      - name: mise action
+        uses: jdx/mise-action@a4cfebde9ceb9b49b54db1d148fa86a52e1b7fab # v2.1.4
+
+      - name: Run bun install
+        run: bun install
+
+      - name: Check for file changes
+        id: diff
+        run: |
+          if git diff --quiet -- 'bun.lockb'; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # https://github.com/marketplace/actions/create-github-app-token
+      - name: Create GitHub App Token
+        if: steps.diff.outputs.changes == 'true'
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ inputs.gh-app-id }}
+          private-key: ${{ secrets.gh-app-private-key }}
+
+      # https://github.com/marketplace/actions/github-script
+      - name: Commit and push changes
+        if: steps.diff.outputs.changes == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { readFileSync } = require('fs');
+            const { resolve } = require('path');
+            const { execSync } = require('child_process');
+
+            const changedFiles = execSync('git diff --name-only')
+              .toString()
+              .split('\n')
+              .filter(Boolean);
+
+            const branch = context.payload.pull_request.head.ref;
+            const { data: parent } = await github.rest.git.getRef({
+              ...context.repo,
+              ref: `heads/${branch}`,
+            });
+
+            const tree = await github.rest.git.createTree({
+              ...context.repo,
+              base_tree: parent.object.sha,
+              tree: changedFiles.map(path => ({
+                path,
+                mode: '100644',
+                content: readFileSync(resolve(process.cwd(), path), 'utf8')
+              }))
+            });
+
+            const commit = await github.rest.git.createCommit({
+              ...context.repo,
+              message: "chore(gen): auto correct some files",
+              tree: tree.data.sha,
+              parents: [parent.object.sha]
+            });
+
+            await github.rest.git.updateRef({
+              ...context.repo,
+              ref: `heads/${branch}`,
+              sha: commit.data.sha
+            });

--- a/.github/workflows/wc-pubspec-locks.yml
+++ b/.github/workflows/wc-pubspec-locks.yml
@@ -1,0 +1,91 @@
+name: 'Correct codes by auto generation'
+
+on:
+  workflow_call:
+    inputs:
+      gh-app-id:
+        required: true
+        type: string
+    secrets:
+      gh-app-private-key:
+        required: true
+
+jobs:
+  gen:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/marketplace/actions/mise-action
+      - name: mise action
+        uses: jdx/mise-action@a4cfebde9ceb9b49b54db1d148fa86a52e1b7fab # v2.1.4
+
+      - name: setup pub
+        uses: ./.github/actions/setup-pub
+
+      - name: Check for file changes
+        id: diff
+        run: |
+          if git diff --quiet -- 'pubspec.lock'; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # https://github.com/marketplace/actions/create-github-app-token
+      - name: Create GitHub App Token
+        if: steps.diff.outputs.changes == 'true'
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ inputs.gh-app-id }}
+          private-key: ${{ secrets.gh-app-private-key }}
+
+      # https://github.com/marketplace/actions/github-script
+      - name: Commit and push changes
+        if: steps.diff.outputs.changes == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { readFileSync } = require('fs');
+            const { resolve } = require('path');
+            const { execSync } = require('child_process');
+
+            const changedFiles = execSync('git diff --name-only')
+              .toString()
+              .split('\n')
+              .filter(Boolean);
+
+            const branch = context.payload.pull_request.head.ref;
+            const { data: parent } = await github.rest.git.getRef({
+              ...context.repo,
+              ref: `heads/${branch}`,
+            });
+
+            const tree = await github.rest.git.createTree({
+              ...context.repo,
+              base_tree: parent.object.sha,
+              tree: changedFiles.map(path => ({
+                path,
+                mode: '100644',
+                content: readFileSync(resolve(process.cwd(), path), 'utf8')
+              }))
+            });
+
+            const commit = await github.rest.git.createCommit({
+              ...context.repo,
+              message: "chore(gen): auto correct some files",
+              tree: tree.data.sha,
+              parents: [parent.object.sha]
+            });
+
+            await github.rest.git.updateRef({
+              ...context.repo,
+              ref: `heads/${branch}`,
+              sha: commit.data.sha
+            });


### PR DESCRIPTION
## Issue

- close #90 🦕

## 概要

<!-- 概要をここに記入してください。 -->

Renovate に対して lock files を追いコミットするワークフローを追加します。

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

- 違和感がないか

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- 

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
